### PR TITLE
chore(QTM-624): Updating component import to restructure payload metrics display

### DIFF
--- a/components/ControlledDialog.jsx
+++ b/components/ControlledDialog.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Button, Dialog } from '@catho/quantum';
+import Button from '@catho/quantum/Button';
+import Dialog from '@catho/quantum/Dialog';
 
 const ControlledDialog = () => {
   const [showDialog, setShowDialog] = useState(false);

--- a/components/ControlledModal.jsx
+++ b/components/ControlledModal.jsx
@@ -1,5 +1,6 @@
 import { Component } from 'react';
-import { Button, Modal } from '@catho/quantum';
+import Button from '@catho/quantum/Button';
+import Modal from '@catho/quantum/Modal';
 
 class ControlledModal extends Component {
   constructor() {

--- a/components/ControlledSnackBar.jsx
+++ b/components/ControlledSnackBar.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, SnackBar } from '@catho/quantum';
+import Button from '@catho/quantum/Button';
+import SnackBar from '@catho/quantum/SnackBar';
 
 class ControlledSnackBar extends React.Component {
   constructor() {

--- a/components/Footer/index.jsx
+++ b/components/Footer/index.jsx
@@ -1,4 +1,4 @@
-import { Container } from '@catho/quantum';
+import Container from '@catho/quantum/Grid/sub-components/Container';
 
 const Footer = () => (
   <Container className="Footer-text">

--- a/components/FooterTagsList.jsx
+++ b/components/FooterTagsList.jsx
@@ -1,4 +1,4 @@
-import { FooterResponsive } from '@catho-private/catho-components';
+import FooterResponsive from '@catho-private/catho-components/FooterResponsive';
 
 const contract = [
   {

--- a/components/Header/index.jsx
+++ b/components/Header/index.jsx
@@ -1,4 +1,4 @@
-import { Container } from '@catho/quantum';
+import Container from '@catho/quantum/Grid/sub-components/Container';
 import NavigationMenu from './Subcomponents/NavigationMenu';
 import Logo from './Subcomponents/Logo';
 

--- a/components/ScrollUpButton/index.jsx
+++ b/components/ScrollUpButton/index.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Button } from '@catho/quantum';
+import Button from '@catho/quantum/Button';
 
 const ScrollUpButton = () => {
   const [scrollUpButton, setScrollUpButton] = useState(false);

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "private": true,
   "dependencies": {
     "@babel/core": "^7.4.5",
-    "@catho-private/catho-components": "6.10.0",
-    "@catho/quantum": "9.16.1",
+    "@catho-private/catho-components": "6.24.0",
+    "@catho/quantum": "9.30.0",
     "@material-ui/core": "^4.5.2",
     "@next/bundle-analyzer": "13.4.4",
     "babel-plugin-external-helpers": "^6.22.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,11 @@
 import App from 'next/app';
 import Head from 'next/head';
 import GlobalStyle from '@catho/quantum/GlobalStyle';
-import { Container } from '@catho/quantum';
+import Container from '@catho/quantum/Grid/sub-components/Container';
 import ScrollUpButton from '../components/ScrollUpButton';
 import '../static/style.css';
-import { Footer, Header } from '../components';
+import Footer from '../components/Footer';
+import Header from '../components/Header';
 
 export default class HomePage extends App {
   render() {

--- a/pages/cathocomponents.js
+++ b/pages/cathocomponents.js
@@ -13,7 +13,11 @@ import {
   JobCard,
   JobNotificationList,
 } from '@catho-private/catho-components';
-import { Container, Row, Col } from '@catho/quantum';
+
+import Container from '@catho/quantum/Grid/sub-components/Container';
+import Row from '@catho/quantum/Grid/sub-components/Row';
+import Col from '@catho/quantum/Grid/sub-components/Col';
+
 import {
   barCharData,
   jobNotificationListMock,
@@ -22,6 +26,7 @@ import {
   passwordProps,
   tagListMocks,
 } from '../mocks/mocks';
+
 import ComponentViewer from '../components/ComponentViewer';
 
 export default function CathoComponentsPage() {

--- a/pages/render.js
+++ b/pages/render.js
@@ -2,7 +2,7 @@ import Container from '@catho/quantum/Grid/sub-components/Container';
 import Col from '@catho/quantum/Grid/sub-components/Col';
 import Row from '@catho/quantum/Grid/sub-components/Row';
 import HeaderResponsive from '@catho-private/catho-components/HeaderResponsive';
-import { FooterTagsList } from '../components';
+import FooterTagsList from '../components/FooterTagsList';
 import Header from './shared/Header';
 
 export default function RenderPage() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -454,35 +454,19 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@catho-private/catho-components@6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@catho-private/catho-components/-/catho-components-6.10.0.tgz#1198810cedc82291c520d9eec01bc835b11ac8d0"
-  integrity sha512-f5ussuGYx7Xx7W9IWhSMXNXx3PegCSj2ZqOj2cbzYNvNIAswCiXw9YKfdPqAeBdcOub7gDgJwTJckrYJh+3aBw==
+"@catho-private/catho-components@6.24.0":
+  version "6.24.0"
+  resolved "https://registry.yarnpkg.com/@catho-private/catho-components/-/catho-components-6.24.0.tgz#123cd3618197f34ef9db877a2a146367d333b65d"
+  integrity sha512-TOnw8mHclHYqoIQL8SyNo88tD+iY8hblH3cmhuMLi36fQXt9iyjk8vx3IKQzHvAph0MSwZ2eL7poCTdMdl/0ag==
   dependencies:
-    "@catho/quantum" "^9.14.0"
+    "@catho/quantum" "^9.24.1"
     prop-types "^15.6.2"
     recharts "2.5.0"
 
-"@catho/quantum@9.16.1":
-  version "9.16.1"
-  resolved "https://registry.yarnpkg.com/@catho/quantum/-/quantum-9.16.1.tgz#a7691bacfdf344a2fedfbe3f138bc1ab644865f3"
-  integrity sha512-e14rrmsyVXGZxY3zZUuCxgVGFbzwvEj31HsX3sESNlyVyyIK7bAe1h9dak7tDeCT1ilg0ZOdR9lpl1s/B7I3bg==
-  dependencies:
-    "@emotion/react" "^11.11.1"
-    "@emotion/styled" "^11.11.0"
-    "@mui/icons-material" "^5.11.16"
-    "@mui/material" "^5.13.5"
-    babel-polyfill "^6.26.0"
-    downshift "^3.1.10"
-    prop-types "^15.6.2"
-    react-slick "^0.29.0"
-    react-text-mask "^5.4.3"
-    slugify "^1.3.6"
-
-"@catho/quantum@^9.14.0":
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/@catho/quantum/-/quantum-9.18.0.tgz#26d0168015ad10891e88e6adb68f2224f7ff2cfa"
-  integrity sha512-z4k+Qy1KhFUqttGYWW83dwNOSZKiOdZxsaooQg4HQybRgRp/Q81xSA5Ut2hFmPoEsDE2KrsWtpJSDZeM1ygmJA==
+"@catho/quantum@9.30.0", "@catho/quantum@^9.24.1":
+  version "9.30.0"
+  resolved "https://registry.yarnpkg.com/@catho/quantum/-/quantum-9.30.0.tgz#2b35121474903555b56d34aff393431e8c904eee"
+  integrity sha512-NnEdSym0tgyZdaHGS8zxuA6AZ8AYupFG50HpoE6cTKZIKUvVOvFoF4VGtzBj9+XEtL6n28tk3WKkhXoInyi3qA==
   dependencies:
     "@emotion/react" "^11.11.1"
     "@emotion/styled" "^11.11.0"


### PR DESCRIPTION
## Description

https://jirasoftware.catho.com.br/browse/QTM-624

#How to test

- Run the `yarn collect` command. This will install the dependencies and run the application.
- In the browser, access the lib page you want to test (/quantum or /cathocomponents)
- Two pages with bundle metrics will open (client and server). Access the page related to client metrics.
- Check if the chunk corresponding to the page you are collecting is displayed